### PR TITLE
Add ring/spill cap options

### DIFF
--- a/src/cvars.cpp
+++ b/src/cvars.cpp
@@ -793,6 +793,8 @@ consvar_t cv_ng_mapringboxes = UnsavedNetVar("ng_mapringboxes", "On").on_off();
 consvar_t cv_ng_maprings = UnsavedNetVar("ng_maprings", "On").on_off();
 consvar_t cv_ng_ringsting = UnsavedNetVar("ng_ringsting", "On").on_off();
 consvar_t cv_ng_capsules = UnsavedNetVar("ng_capsules", "On").on_off();
+consvar_t cv_ng_ringcap = UnsavedNetVar("ng_ringcap", "20").min_max(0, 127);
+consvar_t cv_ng_spillcap = UnsavedNetVar("ng_spillcap", "20").min_max(0, 127);
 consvar_t cv_ng_fastfallbounce = UnsavedNetVar("ng_fastfallbounce", "On").values({
 	{0, "Off"},
 	{1, "Bubble Shield"},

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -76,6 +76,9 @@
 #include "k_credits.h"
 #include "g_gamedata.h"
 
+//Noire
+#include "noire/n_cvar.h"
+
 #ifdef HAVE_DISCORDRPC
 #include "discord.h"
 #endif
@@ -357,7 +360,7 @@ void G_ClearRecords(void)
 
 	// TODO: Technically, these should only remove time attack records here.
 	// But I'm out of juice for dev (+ literally, just finished some OJ).
-	// The stats need to be cleared in M_ClearStats, and I guess there's 
+	// The stats need to be cleared in M_ClearStats, and I guess there's
 	// no perfect place to wipe mapvisited because it's not actually part of
 	// basegame progression... so here's fine for launch.  ~toast 100424
 	unloaded_mapheader_t *unloadedmap, *nextunloadedmap = NULL;
@@ -4529,8 +4532,8 @@ static void G_DoCompleted(void)
 				INT32 ringtotal = player->hudrings;
 				if (ringtotal > 0 && grandprixinfo.eventmode != GPEVENT_SPECIAL)
 				{
-					if (ringtotal > 20)
-						ringtotal = 20;
+					if (ringtotal > cv_ng_ringcap.value)
+						ringtotal = cv_ng_ringcap.value;
 					player->totalring += ringtotal;
 					grandprixinfo.rank.rings += ringtotal;
 				}

--- a/src/k_hud.cpp
+++ b/src/k_hud.cpp
@@ -3015,7 +3015,7 @@ static void K_drawRingCounter(boolean gametypeinfoshown)
 			colorring = false;
 
 	}
-	else if (stplyr->hudrings >= 20) // Maxed out
+	else if (stplyr->hudrings >= cv_ng_ringcap.value) // Maxed out
 		ringmap = R_GetTranslationColormap(TC_RAINBOW, SKINCOLOR_YELLOW, GTC_CACHE);
 
 	if (stplyr->karthud[khud_ringframe] > RINGANIM_FLIPFRAME)

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -3908,11 +3908,11 @@ void K_AwardPlayerRings(player_t *player, UINT16 rings, boolean overload)
 			RINGTOTAL(player) + (player->superring);
 
 		/* capped at 20 rings */
-		if ((totalrings + rings) > 20)
+		if ((totalrings + rings) > cv_ng_ringcap.value)
 		{
-			if (totalrings >= 20)
+			if (totalrings >= cv_ng_ringcap.value)
 				return; // woah dont let that go negative buster
-			rings = (20 - totalrings);
+			rings = (cv_ng_ringcap.value - totalrings);
 		}
 	}
 
@@ -4923,9 +4923,9 @@ INT32 K_ExplodePlayer(player_t *player, mobj_t *inflictor, mobj_t *source) // A 
 		player->spinouttimer = FixedMul(player->spinouttimer, spbMultiplier + ((spbMultiplier - FRACUNIT) / 2));
 
 		ringburst = FixedMul(ringburst * FRACUNIT, spbMultiplier) / FRACUNIT;
-		if (ringburst > 20)
+		if (ringburst > cv_ng_ringcap.value)
 		{
-			ringburst = 20;
+			ringburst = cv_ng_ringcap.value;
 		}
 	}
 
@@ -8317,7 +8317,7 @@ static inline BlockItReturn_t PIT_AttractingRings(mobj_t *thing)
 		return BMIT_CONTINUE; // Too far away
 	}
 
-	if (RINGTOTAL(attractmo->player) >= 20 || (attractmo->player->pflags & PF_RINGLOCK))
+	if (RINGTOTAL(attractmo->player) >= cv_ng_ringcap.value || (attractmo->player->pflags & PF_RINGLOCK))
 	{
 		// Already reached max -- just joustle rings around.
 
@@ -8734,10 +8734,10 @@ void K_KartPlayerThink(player_t *player, ticcmd_t *cmd)
 		player->wipeoutslow = 0;
 	}
 
-	if (player->rings > 20)
-		player->rings = 20;
-	else if (player->rings < -20)
-		player->rings = -20;
+	if (player->rings > cv_ng_ringcap.value)
+		player->rings = cv_ng_ringcap.value;
+	else if (player->rings < -cv_ng_ringcap.value)
+		player->rings = -cv_ng_ringcap.value;
 
 	if (cv_kartdebugbotwhip.value)
 	{
@@ -12356,7 +12356,7 @@ void K_MoveKartPlayer(player_t *player, boolean onground)
 				{
 					if (cv_ng_ringdebt.value)
 					{
-						if (player->rings > -20 && P_IsDisplayPlayer(player))
+						if (player->rings > -cv_ng_ringcap.value && P_IsDisplayPlayer(player))
 							S_StartSound(player->mo, sfx_antiri);
 						player->rings--;
 					}

--- a/src/noire/menu/noire-gameplay.c
+++ b/src/noire/menu/noire-gameplay.c
@@ -43,6 +43,12 @@ menuitem_t OPTIONS_NoireGameplay[] =
 	{IT_HEADER, "Mechanics...", NULL,
 		NULL, {NULL}, 0, 0},
 
+	{IT_STRING | IT_CVAR, "Ring Cap", "Adjust maximum ring count (minimum is maximum negated)",
+		NULL, {.cvar = &cv_ng_ringcap}, 0, 0},
+
+	{IT_STRING | IT_CVAR, "Spill Cap", "Adjust maximum ring loss upon taking damage",
+		NULL, {.cvar = &cv_ng_spillcap}, 0, 0},
+
 	{IT_STRING | IT_CVAR, "Fast Fall Bounce", "Should Fast Fall bounce?",
 		NULL, {.cvar = &cv_ng_fastfallbounce}, 0, 0},
 

--- a/src/noire/n_cvar.h
+++ b/src/noire/n_cvar.h
@@ -21,6 +21,8 @@ extern consvar_t cv_ng_mapringboxes;
 extern consvar_t cv_ng_maprings;
 extern consvar_t cv_ng_ringsting;
 extern consvar_t cv_ng_capsules;
+extern consvar_t cv_ng_ringcap;
+extern consvar_t cv_ng_spillcap;
 extern consvar_t cv_ng_fastfallbounce;
 extern consvar_t cv_ng_draft;
 extern consvar_t cv_ng_instawhip;

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -49,6 +49,7 @@
 #include "m_easing.h"
 #include "k_hud.h" // K_AddMessage
 
+//Noire
 #include "noire/n_cvar.h"
 
 
@@ -680,7 +681,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher, boolean heightcheck)
 				return;
 
 			// Reached the cap, don't waste 'em!
-			if (RINGTOTAL(player) >= 20)
+			if (RINGTOTAL(player) >= cv_ng_ringcap.value)
 				return;
 
 			special->momx = special->momy = special->momz = 0;
@@ -2576,7 +2577,7 @@ static boolean P_KillPlayer(player_t *player, mobj_t *inflictor, mobj_t *source,
 				{
 					player->mo->health--;
 				}
-				
+
 			}
 
 			if (modeattacking & ATTACKING_SPB)
@@ -3255,7 +3256,7 @@ boolean P_DamageMobj(mobj_t *target, mobj_t *inflictor, mobj_t *source, INT32 da
 				}
 			}
 
-			if (player->rings <= -20)
+			if (player->rings <= -cv_ng_ringcap.value)
 			{
 				player->markedfordeath = true;
 				damagetype = DMG_TUMBLE;
@@ -3530,8 +3531,8 @@ void P_PlayerRingBurst(player_t *player, INT32 num_rings)
 		return;
 
 	// 20 is the maximum number of rings that can be taken from you at once - half the span of your counter
-	if (num_rings > 20)
-		num_rings = 20;
+	if (num_rings > cv_ng_spillcap.value)
+		num_rings = cv_ng_spillcap.value;
 	else if (num_rings <= 0)
 		return;
 

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -461,10 +461,10 @@ INT32 P_GivePlayerRings(player_t *player, INT32 num_rings)
 	}
 
 	test = player->rings + num_rings;
-	if (test > 20) // Caps at 20 rings, sorry!
-		num_rings -= (test-20);
-	else if (test < -20) // Chaotix ring debt!
-		num_rings -= (test+20);
+	if (test > cv_ng_ringcap.value) // Caps at 20 rings, sorry!
+		num_rings -= (test-cv_ng_ringcap.value);
+	else if (test < -cv_ng_ringcap.value) // Chaotix ring debt!
+		num_rings -= (test+cv_ng_ringcap.value);
 
 	player->rings += num_rings;
 
@@ -1284,8 +1284,8 @@ void P_DoPlayerExit(player_t *player, pflags_t flags)
 		if (!(gametyperules & GTR_SPHERES))
 		{
 			player->hudrings = RINGTOTAL(player);
-			if (player->hudrings > 20)
-				player->hudrings = 20;
+			if (player->hudrings > cv_ng_ringcap.value)
+				player->hudrings = cv_ng_ringcap.value;
 
 			if (grandprixinfo.gp == true
 				&& grandprixinfo.eventmode != GPEVENT_SPECIAL
@@ -2219,7 +2219,7 @@ static INT16 P_FindClosestTurningForAngle(player_t *player, INT32 targetAngle, I
 
 	// Slightly frumpy binary search for the ideal turning input.
 	// We do this instead of reversing K_GetKartTurnValue so that future handling changes are automatically accounted for.
-	
+
 	while (attempts++ < 20) // Practical calls of this function search maximum 10 times, this is solely for safety.
 	{
 		// These need to be treated as signed, or situations where boundaries straddle 0 are a mess.
@@ -2340,7 +2340,7 @@ static void P_UpdatePlayerAngle(player_t *player)
 		// Corrections via fake turn go through easing.
 		// That means undoing them takes the same amount of time as doing them.
 		// This can lead to oscillating death spiral states on a multi-tic correction, as we swing past the target angle.
-		// So before we go into death-spirals, if our predicton is _almost_ right... 
+		// So before we go into death-spirals, if our predicton is _almost_ right...
 		angle_t leniency = (4*ANG1/3) * min(player->cmd.latency, 6);
 		// Don't force another turning tic, just give them the desired angle!
 
@@ -2439,7 +2439,7 @@ void P_MovePlayer(player_t *player)
 	//////////////////////
 
 	P_UpdatePlayerAngle(player);
-	
+
 	ticruned++;
 	if (!(cmd->flags & TICCMD_RECEIVED))
 		ticmiss++;
@@ -4539,7 +4539,7 @@ void P_PlayerThink(player_t *player)
 	{
 		player->stairjank--;
 	}
-	
+
 	// Random skin / "ironman"
 	{
 		UINT32 skinflags = (demo.playback)


### PR DESCRIPTION
This adds the ability to change the ring and ring spill caps to a value between 0 and 127. Setting the ring cap to 0 essentially force-disables all ring functionality, while 127 is the maximum number of rings allowed before the counter overflows.